### PR TITLE
Fix bug to read/write pmpcfg csr

### DIFF
--- a/target/riscv/pmp.c
+++ b/target/riscv/pmp.c
@@ -310,6 +310,9 @@ void pmpcfg_csr_write(CPURISCVState *env, uint32_t reg_index,
         return;
     }
 
+    if ((sizeof(target_ulong) == 8))
+        reg_index /= 2;
+
     for (i = 0; i < sizeof(target_ulong); i++) {
         cfg_val = (val >> 8 * i)  & 0xff;
         pmp_write_cfg(env, (reg_index * sizeof(target_ulong)) + i,
@@ -326,6 +329,9 @@ target_ulong pmpcfg_csr_read(CPURISCVState *env, uint32_t reg_index)
     int i;
     target_ulong cfg_val = 0;
     uint8_t val = 0;
+    
+    if ((sizeof(target_ulong) == 8))
+        reg_index /= 2;
 
     for (i = 0; i < sizeof(target_ulong); i++) {
         val = pmp_read_cfg(env, (reg_index * sizeof(target_ulong)) + i);


### PR DESCRIPTION
```c
    for (i = 0; i < sizeof(target_ulong); i++) {
        cfg_val = (val >> 8 * i)  & 0xff;
        pmp_write_cfg(env, (reg_index * sizeof(target_ulong)) + i,
            cfg_val);
    }
```
RV64 PMP config register is pmpcfg0/pmpcfg2 not pmpcfg0/pmpcfg1.
So under RV64, needs to convert the register index to 0/1.
If not do that will overflow.
`reg_index * sizeof(target_ulong) + i` will between [0, 8) / [16, 24)