### PR TITLE
fix bug of pmpcfg_csr_write/pmpcfg_csr_read

### DIFF
--- a/target/riscv/pmp.c
+++ b/target/riscv/pmp.c
@@ -310,6 +310,9 @@ void pmpcfg_csr_write(CPURISCVState *env, uint32_t reg_index,
         return;
     }
 
+    if(sizeof(target_ulong) == 8)
+        reg_index /= 2;
+
     for (i = 0; i < sizeof(target_ulong); i++) {
         cfg_val = (val >> 8 * i)  & 0xff;
         pmp_write_cfg(env, (reg_index * sizeof(target_ulong)) + i,
@@ -326,6 +329,9 @@ target_ulong pmpcfg_csr_read(CPURISCVState *env, uint32_t reg_index)
     int i;
     target_ulong cfg_val = 0;
     uint8_t val = 0;
+
+    if(sizeof(target_ulong) == 8)
+        reg_index /= 2;
 
     for (i = 0; i < sizeof(target_ulong); i++) {
         val = pmp_read_cfg(env, (reg_index * sizeof(target_ulong)) + i);


### PR DESCRIPTION
Configuration register under RV32: pmpcfg0/pmpcfg1/pmpcfg2/pmpcfg3.
Configuration register under RV64: pmpcfg0/pmpcfg2.

pmpcfg_csr_write/pmpcfg_csr_read calculates the index by the following expression:
```c
reg_index * sizeof(target_ulong)) + i
```

Possible values for expressions under RV32 -> [0, 3] [4, 7] [8, 11] [12, 15]. this is ok
Possible values for expressions under RV64 -> [0, 7] [16, 23]. this is error

So needs to add this code.